### PR TITLE
Use the "npm start" way to run the app on Heroku instead of Procfile

### DIFF
--- a/public/lessons/server_side_javascript/hello_node.md
+++ b/public/lessons/server_side_javascript/hello_node.md
@@ -29,18 +29,6 @@ http.createServer(function(request, response){
 
 - Visit <http://localhost:5000/> to see it running on your own computer.
 
-# Hello, Procfile!
-
-A *Procfile* tells Heroku what commands to run when it launches your app.
-
-Go back to Atom and create a file named `Procfile` (there is *no extension* on this filename) and fill it with this:
-
-```
-web: node index.js
-```
-
-> Note that the code after `web:` is *exactly* what you typed to run the app locally.
-
 # Hello, NPM!
 
 You also need a `package.json` file. The easiest way to get one is to run
@@ -63,6 +51,23 @@ Wrote to C:\Users\alex\code\hello_node\package.json:
   "keywords": [],
   "author": "",
   "license": "ISC"
+}
+```
+
+# Hello, Start!
+
+You will need to add one line to the generated `package.json` file.
+
+The `npm start` command tells Heroku what to run when it launches your app.
+
+Go back to Atom and edit the file named `package.json` and add this line:
+
+> Remember to end the `"start": "node index.js"` line with a comma!
+
+```json
+"scripts": {
+  "start": "node index.js", // ADD THIS LINE HERE
+  "test": "echo \"Error: no test specified\" && exit 1"
 }
 ```
 


### PR DESCRIPTION
Procfile syntax is different than Javascript or JSON and may lead to confusion
for students around meaningful whitespace and the weird Procfile extension-less
filename which is not consistent with the rest of the files in the app.

Heroku will use "npm start" over Procfile if that script is defined within the
"package.json" file during the application startup phase of deployment.